### PR TITLE
Remove versions from the guide content.

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -45,13 +45,13 @@ In order to configure Hazelcast as second-level cache provider, you need to add 
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-hibernate53</artifactId>
-    <version>2.1.0</version>
+    <version>${hazelcast-hibernate.version}</version>
 </dependency>
 
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast</artifactId>
-    <version>4.0.2</version>
+    <version>${hazelcast.version}</version>
 </dependency>
 ----
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<hazelcast.vesion>4.0.2</hazelcast.vesion>
+		<hazelcast.version>4.0.2</hazelcast.version>
 		<hazelcast-hibernate.version>2.1.1</hazelcast-hibernate.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+		<hazelcast.vesion>4.0.2</hazelcast.vesion>
+		<hazelcast-hibernate.version>2.1.1</hazelcast-hibernate.version>
 	</properties>
 
 	<build>
@@ -49,13 +51,13 @@
 		<dependency>
 			<groupId>com.hazelcast</groupId>
 			<artifactId>hazelcast-hibernate53</artifactId>
-			<version>2.1.1</version>
+			<version>${hazelcast-hibernate.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.hazelcast</groupId>
 			<artifactId>hazelcast</artifactId>
-			<version>4.0.2</version>
+			<version>${hazelcast.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The guide content can point to older versions after version updates on pom (i.e. currently it's 2.1.0 on content where 2.1.1 on pom.xml for hazelcast-hibernate). Hence not having the coded versions on the content might be better.